### PR TITLE
CRUD Finalizado

### DIFF
--- a/CRUD-Neo4j/config/db/dbConfig.js
+++ b/CRUD-Neo4j/config/db/dbConfig.js
@@ -1,0 +1,7 @@
+const dbConfig = {
+URI: process.env.URI,
+USER: process.env.USER,
+PASSWORD: process.env.PASSWORD
+}
+
+module.exports = dbConfig

--- a/CRUD-Neo4j/config/db/dbConnection.js
+++ b/CRUD-Neo4j/config/db/dbConnection.js
@@ -1,14 +1,10 @@
-const neo4j = require('neo4j-driver');
+const neo4j    = require('neo4j-driver');
+const dbConfig = require('./dbConfig')
+
 
 const dbConnection = async () => {
-
-const URI = process.env.URI;
-const USER = process.env.USER;
-const PASSWORD = process.env.PASSWORD; 
-
 try {
-
-const driver = neo4j.driver(URI, neo4j.auth.basic(USER, PASSWORD));
+const driver = neo4j.driver(dbConfig.URI, neo4j.auth.basic(dbConfig.USER, dbConfig.PASSWORD));
 
 const serverInfo = await driver.getServerInfo();
 console.log(`Conexão com o banco estabelecida com sucesso.`);

--- a/CRUD-Neo4j/controllers/directorController.js
+++ b/CRUD-Neo4j/controllers/directorController.js
@@ -1,0 +1,240 @@
+const neo4j = require('neo4j-driver');
+const dbConfig = require('../config/db/dbConfig');
+
+const driver = neo4j.driver(dbConfig.URI, neo4j.auth.basic(dbConfig.USER, dbConfig.PASSWORD));
+
+const directorController = {
+
+  // cria um novo diretor
+  create: async (req, res) => {
+    const session = driver.session();
+    try {
+      const name = req.body.name;
+
+      // valida se o nome recebido está em formato válido.
+      
+      const validateName = /^[a-zA-ZÀ-ÿ\s]+$/
+      if (!name || name === 'undefined' || !validateName.test(name)) {
+        return res.status(403).json({ msg: "O parâmetro não foi informado ou possui valor inválido." })
+      }
+      const result = await session.run(
+        `MERGE (d:Director {director_name: "${name}"}) RETURN d`
+      );
+
+      const response = {
+        records: result.records,
+      };
+
+      res.status(201).json({ response, msg: "diretor criado com sucesso." });
+    } catch (error) {
+      console.log(error);
+      res.status(500).json({ msg: "Não foi possível realizar a criação do diretor." });
+    } finally {
+      if (session) await session.close();
+    }
+  },
+
+  // busca o diretor pelo nome
+  getDirectorByName: async (req, res) => {
+    const session = driver.session();
+    try {
+      const name = req.query.name
+
+      const validateName = /^[a-zA-ZÀ-ÿ\s]+$/
+
+
+      if (!name || name === 'undefined' || !validateName.test(name)) {
+        return res.status(403).json({ msg: "O parâmetro não foi informado ou possui valor inválido." })
+      }
+
+      const result = await session.run(
+        `MATCH (d:Director {director_name: "${name}"}) RETURN d`
+      );
+
+      if (result.records.length === 0) {
+        return res.status(404).json({ msg: "diretor não encontrado." });
+      }
+
+      const response = {
+        records: result.records,
+      };
+
+      res.status(200).json({ response, msg: "Diretor encontrado com sucesso." });
+
+    } catch (error) {
+      console.log(error);
+      res.status(500).json({ msg: "Não foi possível realizar a busca." });
+    }
+    finally {
+      if (session) await session.close();
+    }
+  },
+
+  // busca um conjunto de diretores com a quantia determinada nos parâmetros da requisição.
+  getAllDirectorsInRange: async (req, res) => {
+    const session = driver.session()
+    try {
+      const range = req.query.range
+
+      if (!range || range === 'undefined' || isNaN(range)) {
+        const result = await session.run(
+          `MATCH (d:Director) RETURN d LIMIT 10`
+        )
+        const response = {
+          totalRecords: result.records.length,
+          records: result.records,
+        };
+
+        return res.status(200).json({ response, msg: "Diretores retornados com sucesso." })
+      }
+      const query = `MATCH (d:Director) RETURN d LIMIT ${range}`
+      const result = await session.run(query)
+
+      const response = {
+        totalRecords: result.records.length,
+        records: result.records,
+      };
+      res.status(200).json({ response, msg: "Diretores retornados com sucesso." })
+
+    } catch (error) {
+      console.log(error);
+      res.status(500).json({ msg: "Não foi possível realizar a busca." });
+    }
+    finally {
+      if (session) await session.close();
+    }
+  },
+
+  // busca os filmes que um determinado diretor dirigiu.
+  getFilmsDirectorRel: async (req, res) => {
+    const session = driver.session()
+    try {
+      const { name, range } = req.query
+
+      // valida se o nome é válido
+
+      const validateName = /^[a-zA-ZÀ-ÿ\s]+$/
+      if (!name || name === 'undefined' || !validateName.test(name)) {
+        return res.status(403).json({ msg: "O parâmetro não foi informado ou possui valor inválido." })
+      }
+
+      // checa se a requisição possui o "range".
+
+      if (!range || range === 'undefined') {
+        const result = await session.run(`MATCH (d:Director {director_name: "${name}"})<-[r:DIRECTED_BY]-(s:ShowCatalog) RETURN d, r, s`)
+        const response = {
+          totalRecords: result.records.length,
+          records: result.records,
+        };
+        res.status(200).json({ response, msg: "Busca concluída com sucesso." });
+      }
+
+      // Query caso tenha todos os dados da requisição.
+      const query = `MATCH (d:Director {director_name: "${name}"})<-[r:DIRECTED_BY]-(s:ShowCatalog) RETURN d, r, s LIMIT ${range} `
+      const result = await session.run(query)
+
+      // verifica se ele já existe.
+
+      if (result.records.length === 0) {
+        return res.status(404).json({ msg: "diretor não encontrado." });
+      }
+      const response = {
+        totalRecords: result.records.length,
+        records: result.records,
+      };
+      res.status(200).json({ response, msg: "Busca concluída com sucesso." });
+
+
+    } catch (error) {
+      console.log(error);
+      res.status(500).json({ msg: "Não foi possível realizar a busca." });
+    } finally {
+      if (session) await session.close();
+    }
+  },
+
+  update: async (req, res) => {
+    const session = driver.session()
+    try {
+      const { name, newName } = req.body;
+
+      const validateName = /^[a-zA-ZÀ-ÿ\s]+$/
+
+      if (!name || name === 'undefined' || !newName || newName === 'undefined' || !validateName.test(name) || !validateName.test(newName)) {
+        return res.status(403).json({ msg: "um dos parâmetros não foi informado ou possui valor inválido." })
+      }
+      
+      const query = `MATCH (d:Director) 
+                    WHERE d.director_name = "${name}"
+                    SET d.director_name = "${newName}" 
+                    RETURN d`
+
+      const result = await session.run(query)
+      if (result.records.length === 0) {
+        return res.status(404).json({ msg: "diretor não encontrado." });
+      }
+
+      const updateDirectorQuery = `
+      MATCH (sc:ShowCatalog)
+      WHERE "${name}" = sc.director
+      SET sc.director = "${newName}"`
+
+      const updateResult = await session.run(updateDirectorQuery)
+
+      if(updateResult.records.length === 0){
+        return res.status(200).json({msg: "O diretor mencionado foi atualizado, mas não possui relacioanmentos."})
+      }
+      const response = {
+        records: updateResult.records,
+      };
+
+
+      res.status(201).json({ response, msg: "Diretor atualizado com sucesso." })
+    } catch (error) {
+      console.log(error);
+      res.status(500).json({ msg: "Não foi possível realizar a busca." });
+    } finally {
+      if (session) await session.close();
+    }
+  },
+
+  // apaga um registro
+
+  delete: async (req, res) => {
+    const session = driver.session();
+
+    try {
+
+      const name = req.body.name;
+
+      const validateName = /^[a-zA-ZÀ-ÿ\s]+$/
+      if (!name || name === 'undefined' || !validateName.test(name)) {
+        return res.status(403).json({ msg: "O parâmetro não foi informado ou possui valor inválido." })
+      }
+
+      const query = `MATCH(d:Director)
+      WHERE d.director_name = "${name}"
+      DETACH DELETE d
+      RETURN d`
+      const result = await session.run(query)
+
+      if (result.records.length === 0) {
+        return res.status(404).json({ msg: "diretor não encontrado." });
+      }
+
+      const response = {
+        records: result.records,
+      }
+      res.status(200).json({ response, msg: "diretor apagado com sucesso." })
+
+    } catch (error) {
+      console.log(error);
+      res.status(500).json({ msg: "Não foi possível encontrar o diretor especificado." });
+    } finally {
+      if (session) await session.close();
+    }
+  }
+
+};
+
+module.exports = directorController;

--- a/CRUD-Neo4j/controllers/relController.js
+++ b/CRUD-Neo4j/controllers/relController.js
@@ -1,0 +1,295 @@
+const neo4j = require('neo4j-driver');
+const dbConfig = require('../config/db/dbConfig');
+
+const driver = neo4j.driver(dbConfig.URI, neo4j.auth.basic(dbConfig.USER, dbConfig.PASSWORD));
+
+
+const relController = {
+
+
+  // Cria o relacionamento entre os atributos director, cast e country do show.
+
+  create: async (req, res) => {
+    const session = driver.session()
+    try {
+      const id = req.body.id
+      const newId = parseInt(id)
+
+      const query = `
+      MATCH (sc:ShowCatalog {id: ${newId}})
+      MERGE (d:Director {director_name: sc.director})
+      MERGE (c:Country {name_country: sc.country})
+      WITH sc, d, c
+      UNWIND split(sc.cast, ', ') AS actor_name
+      MERGE (a:Actor {actor_name: actor_name})
+      MERGE (sc)-[:DIRECTED_BY]->(d)
+      MERGE (sc)-[:LOCATED_IN]->(c)
+      MERGE (sc)-[:HAS_CAST]->(a)
+      RETURN sc, d, c, a;
+      
+      `;
+      
+      const result = await session.run(query)
+  
+      const response = {
+        result: result.records.map(record => ({
+          sc: record.get('sc').properties
+        }))[0] 
+      }
+  
+      res.status(201).json({ response, msg: "Ligação entre os nós criada com sucesso." })
+    } catch (error) {
+      console.error("Erro ao criar relacionamento:", error);
+      res.status(500).json({ msg: "Erro interno do servidor ao criar relacionamento." });
+    } finally {
+      await session.close()
+    }
+  },
+
+  // Cria relacionamento entre diretor e show, além de adicionar o diretor na prop director
+  createRelDirectorShow: async (req, res) => {
+    const session = driver.session()
+    try {
+      const {showId, director_name} = req.body;
+
+      const id = parseInt(showId)
+
+      const query = `MATCH (d:Director {director_name: "${director_name}"})
+      MATCH (sc:ShowCatalog {id: ${id}})
+      MERGE (d)-[:DIRECTED_BY]->(sc)
+      RETURN d, sc;
+      `
+      const result = await session.run(query)
+      if (result.records.length === 0) {
+        return res.status(404).json({ msg: "Um dos nós informados não existe ou não foi encontrado." });
+    }
+
+    const updateDiretorShowQuery = `
+    MATCH (d:Director {director_name: "${director_name}"})
+    MATCH (sc:ShowCatalog {id: ${id}})
+
+SET sc.director = 
+  CASE 
+    WHEN sc.director IS NOT NULL THEN sc.director + ", ${director_name}"
+    ELSE "${director_name}"
+  END
+
+RETURN d, sc`
+
+    const resultSecondQuery = await session.run(updateDiretorShowQuery)
+
+      const response = {
+        record: resultSecondQuery.records
+      }
+      res.status(201).json({response, msg: "Relacionamento criado com sucesso!."})
+
+    } catch (error) {
+      console.error("Erro ao criar relacionamento:", error);
+      res.status(500).json({ msg: "Erro interno do servidor ao criar relacionamento." });
+    } finally {
+      await session.close()
+    }
+  },
+
+  // Cria relacionamento entre diretor e show, além de adicionar o diretor na prop director
+  
+  createRelActorShow: async (req, res) => {
+    const session = driver.session()
+    try {
+      const {showId, actor_name} = req.body;
+
+      const id = parseInt(showId)
+
+      const query = `MATCH (a:Actor {actor_name: "${actor_name}"})
+      MATCH (sc:ShowCatalog {id: ${id}})
+      MERGE (a)-[:HAS_CAST]->(sc)
+      RETURN a, sc;
+      `
+      
+      const result = await session.run(query)
+      if (result.records.length === 0) {
+        return res.status(404).json({ msg: "Um dos nós informados não existe ou não foi encontrado." });
+    }
+
+    const updateActorShowQuery = `
+    MATCH (a:Actor {actor_name: "${actor_name}"})
+    MATCH (sc:ShowCatalog {id: ${id}})
+
+SET sc.cast = 
+  CASE 
+    WHEN sc.cast IS NOT NULL THEN sc.cast + ", ${actor_name}"
+    ELSE "${actor_name}"
+  END
+
+RETURN a, sc`
+
+      const resultSecondQuery = await session.run(updateActorShowQuery)
+
+      const response = {
+        record: resultSecondQuery.records
+      }
+      res.status(201).json({response, msg: "Relacionamento criado com sucesso!."})
+
+    } catch (error) {
+      console.error("Erro ao criar relacionamento:", error);
+      res.status(500).json({ msg: "Erro interno do servidor ao criar relacionamento." });
+    } finally {
+      await session.close()
+    }
+  },
+
+  createRelCountryShow: async (req, res) => {
+    const session = driver.session()
+    try {
+      const {showId, name_country} = req.body;
+
+      const id = parseInt(showId)
+
+      const query = `MATCH (c:Country {name_country: "${name_country}"})
+      MATCH (sc:ShowCatalog {id: ${id}})
+      MERGE (c)-[:LOCATED_IN]->(sc)
+      RETURN c, sc;
+      `
+      const result = await session.run(query)
+      if (result.records.length === 0) {
+        return res.status(404).json({ msg: "Um dos nós informados não existe ou não foi encontrado." });
+    }
+
+
+    // Pega a country e adiciona na lista de países na propriedade country de ShowCatalog, 
+    // Além disso, cria os relacionamentos entre country e show.
+
+    const updateCountryShowQuery = `
+    MATCH (c:Country {name_country: "${name_country}"})
+    MATCH (sc:ShowCatalog {id: ${id}})
+
+SET sc.country = 
+  CASE 
+    WHEN sc.country IS NOT NULL THEN sc.country + ", ${name_country}"
+    ELSE "${name_country}"
+  END
+
+RETURN c, sc`
+
+      const resultSecondQuery = await session.run(updateCountryShowQuery)
+
+      const response = {
+        record: resultSecondQuery.records
+      }
+      res.status(201).json({response, msg: "Relacionamento criado com sucesso!."})
+      
+
+    } catch (error) {
+      console.error("Erro ao criar relacionamento:", error);
+      res.status(500).json({ msg: "Erro interno do servidor ao criar relacionamento." });
+    } finally {
+      await session.close()
+    }
+  },
+
+
+  getActorShows: async (req, res) => {
+    const session = driver.session()
+    try {
+      const name = req.query.name
+      console.log(name)
+
+      if (name === 'undefined') {
+        return res.status(403).json({ msg: "O parâmetro não foi informado ou possui valor inválido." })
+      }
+      const query = `MATCH (a:Actor {actor_name: "${name}"})<-[r:HAS_CAST]-(sc:ShowCatalog) 
+                      RETURN a, r, sc`
+
+      const result = await session.run(query)
+
+      if(result.records.length === 0){
+        return res.status(404).json({msg: "Não foi possível encontrar o ator mencionado no relacionamento"})
+      }
+
+      const response = {
+        record: result.records
+      }
+      
+      res.status(200).json({response, msg: "Relacionamento entre ator e show retornado com sucesso!"})
+
+    } catch (error) {
+      console.error("Erro ao retornar relacionamento:", error);
+      res.status(500).json({ msg: "Erro interno do servidor ao retornar relacionamento." });
+    }finally{
+      await session.close()
+    }
+  },
+
+
+  getDirectorShows: async (req, res) => {
+    const session = driver.session()
+    try {
+      const name = req.query.name
+
+      if (name === 'undefined') {
+        return res.status(403).json({ msg: "O parâmetro não foi informado ou possui valor inválido." })
+      }
+      const query = `MATCH (d:Director {director_name: "${name}"})<-[r:DIRECTED_BY]-(sc:ShowCatalog) 
+                      RETURN d, r, sc`
+
+      const result = await session.run(query)
+
+      if(result.records.length === 0){
+        return res.status(404).json({msg: "Não foi possível encontrar o diretor mencionado no relacionamento"})
+      }
+
+      const response = {
+        record: result.records
+      }
+      
+      res.status(200).json({response, msg: "Relacionamento entre diretor e show retornado com sucesso!"})
+      
+    } catch (error) {
+      console.error("Erro ao retornar relacionamento:", error);
+      res.status(500).json({ msg: "Erro interno do servidor ao retornar o relacionamento." });
+    }finally{
+      await session.close()
+    }
+  },
+
+
+  getCountryShows: async (req, res) => {
+    const session = driver.session()
+    try {
+      const name = req.query.name
+
+      if (name === 'undefined') {
+        return res.status(403).json({ msg: "O parâmetro não foi informado ou possui valor inválido." })
+      }
+      const query = `MATCH (c:Country {name_country: "${name}"})<-[r:LOCATED_IN]-(sc:ShowCatalog) 
+                      RETURN c, r, sc`
+
+      const result = await session.run(query)
+
+      if(result.records.length === 0){
+        return res.status(404).json({msg: "Não foi possível encontrar o país mencionado no relacionamento"})
+      }
+
+      const response = {
+        record: result.records
+      }
+      
+      res.status(200).json({response, msg: "Relacionamento entre país e show retornado com sucesso!"})
+
+    } catch (error) {
+      console.error("Erro ao retornar o relacionamento:", error);
+      res.status(500).json({ msg: "Erro interno do servidor ao retornar relacionamento." });
+    }finally{
+      await session.close()
+    }
+  }
+  
+}
+  
+
+module.exports = relController
+
+
+
+
+

--- a/CRUD-Neo4j/controllers/showController.js
+++ b/CRUD-Neo4j/controllers/showController.js
@@ -1,0 +1,307 @@
+const neo4j = require('neo4j-driver');
+const dbConfig = require('../config/db/dbConfig');
+
+const driver = neo4j.driver(dbConfig.URI, neo4j.auth.basic(dbConfig.USER, dbConfig.PASSWORD));
+
+const showController = {
+
+  create: async (req, res) => {
+    const session = driver.session();
+    try {
+      const { id, title, description_show, duration, date_added, country, rating, director, type_show, release_year,
+        cast, listed_in } = req.body
+      const validateIfIsString = /^[a-zA-ZÀ-ÿ\s]+$/;
+      const validateData = /^(?:20\d{2})-(?:0[1-9]|1[0-2])-(?:0[1-9]|[12][0-9]|3[01])$/;
+      const validateRating = /^(PG-13|TV-Y|TV-14|TV-MA|TV-PG|R|TV-G)$/;
+      const validateTypeShow = /^(TV Show|movie)$/;
+      const validateYear = /^\d{4}$/;
+
+      // verifica se o id já existe.
+
+      checkId = `MATCH (s:ShowCatalog {id: ${id}}) RETURN s.id`
+      const checkIdQuery = await session.run(checkId)
+
+      if (checkIdQuery.records.length !== 0) {
+        return res.status(400).json({ msg: "O id mencionado já existe." })
+      }
+
+      if (isNaN(id)) {
+        return res.status(403).json({ msg: "o id passado na requisição está em um formato inválido." });
+
+      } else if (!validateIfIsString.test(title)) {
+
+        return res.status(403).json({ msg: "o titulo passado na requisição está em um formato inválido." });
+      } else if (!validateIfIsString.test(description_show)) {
+        return res.status(403).json({ msg: "A descrição do show passada na requisição está em um formato inválido." });
+
+      } else if (duration.length > 45) {
+        return res.status(403).json({ msg: "A duração do show passada na requisição está em um formato inválido." });
+      }
+
+      else if (!validateData.test(date_added)) {
+        return res.status(403).json({ msg: "A data de adição do show informada  está em um formato inválido." });
+      }
+
+      else if (!validateIfIsString.test(country)) {
+        return res.status(403).json({ msg: "O país informado  está em um formato inválido." });
+
+
+      } else if (!validateRating.test(rating)) {
+        return res.status(403).json({ msg: "A classificação indicativa está em um formato inválido." });
+
+
+      } else if (!validateIfIsString.test(director)) {
+        return res.status(403).json({ msg: "O diretor está em um formato inválido." });
+
+
+      } else if (!validateTypeShow.test(type_show)) {
+        return res.status(403).json({ msg: "O tipo de show informado está em um formato inválido." });
+
+
+      } else if (!validateYear.test(release_year)) {
+        return res.status(403).json({ msg: "o ano de lançamento está em um formato inválido." });
+
+
+      } else if (typeof cast !== 'string') {
+        return res.status(403).json({ msg: "O formato do elenco passado está em um formato inválido." });
+
+
+      } else if (!validateIfIsString.test(listed_in)) {
+        return res.status(403).json({ msg: "O listed_in passado está em um formato inválido." });
+      }
+
+      const query = `CREATE (s:ShowCatalog {
+        id: toInteger(${id}),
+        type_show: "${type_show}",
+        title: "${title}",
+        director: "${director}",
+        cast: "${cast}",
+        country: "${country}",
+        date_added: "${date_added}",
+        release_year: toInteger(${release_year}),
+        rating: "${rating}",
+        duration: "${duration}",
+        listed_in: "${listed_in}",
+        description_show: "${description_show}"
+    })
+        `
+      await session.run(query)
+
+      const response = {
+        id: id,
+        title: title,
+        description_show: description_show,
+        duration: duration,
+        date_added: date_added,
+        country: country,
+        rating: rating,
+        director: director,
+        type_show: type_show,
+        release_year: release_year,
+        cast: cast,
+        listed_in: listed_in
+      }
+      res.status(201).json({ response, msg: "Show criado com sucesso." });
+
+    } catch (error) {
+
+      console.log(error);
+      res.status(500).json({ msg: "Não foi possível realizar a criação do show." });
+    } finally {
+      if (session) await session.close();
+    }
+  },
+
+  getAll: async (req, res) => {
+    const session = driver.session()
+    try {
+
+      const query = `MATCH (s:ShowCatalog) RETURN s`
+      const result = await session.run(query)
+
+      const response = {
+        record: result.records
+      }
+
+      res.status(200).json({ response, msg: "Shows encontrados com sucesso." })
+
+    } catch (error) {
+      console.log(error);
+      res.status(500).json({ msg: "Ocorreu um erro interno no servidor." });
+    } finally {
+      if (session) await session.close();
+    }
+  },
+
+  getById: async (req, res) => {
+    const session = driver.session()
+    try {
+      const id = req.query.id
+
+      const query = `MATCH (s:ShowCatalog {id: ${id}}) RETURN s`
+      const result = await session.run(query)
+      if (result.records.length === 0) {
+        return res.status(404).json({ msg: "Não foi possível encontrar o show informado." })
+      }
+      const response = {
+        records: result.records
+      }
+      res.status(200).json({ response, msg: "Show encontrado com sucesso." })
+
+    } catch (error) {
+      console.log(error);
+      res.status(500).json({ msg: "Não foi possível realizar a criação do show." });
+    } finally {
+      if (session) await session.close();
+    }
+  },
+
+  update: async (req, res) => {
+    const session = driver.session()
+    try {
+      const { id, title, description_show, duration, date_added, country, rating, director, type_show, release_year,
+        cast, listed_in } = req.body
+      const validateIfIsString = /^[a-zA-ZÀ-ÿ\s]+$/;
+      const validateData = /^(?:20\d{2})-(?:0[1-9]|1[0-2])-(?:0[1-9]|[12][0-9]|3[01])$/;
+      const validateRating = /^(PG-13|TV-Y|TV-14|TV-MA|TV-PG|R|TV-G)$/;
+      const validateTypeShow = /^(TV Show|movie)$/;
+      const validateYear = /^\d{4}$/;
+
+      // verifica se o id já existe.
+
+      checkId = `MATCH (s:ShowCatalog {id: ${id}}) RETURN s.id`
+      const checkIdQuery = await session.run(checkId)
+
+      if (checkIdQuery.records.length === 0) {
+        return res.status(404).json({ msg: "o show mencionado não existe." })
+      }
+
+      if (isNaN(id)) {
+        return res.status(403).json({ msg: "o id passado na requisição está em um formato inválido." });
+
+      } else if (!validateIfIsString.test(title)) {
+
+        return res.status(403).json({ msg: "o titulo passado na requisição está em um formato inválido." });
+      } else if (!validateIfIsString.test(description_show)) {
+        return res.status(403).json({ msg: "A descrição do show passada na requisição está em um formato inválido." });
+
+      } else if (duration.length > 45) {
+        return res.status(403).json({ msg: "A duração do show passada na requisição está em um formato inválido." });
+      }
+
+      else if (!validateData.test(date_added)) {
+        return res.status(403).json({ msg: "A data de adição do show informada  está em um formato inválido." });
+      }
+
+      else if (!validateIfIsString.test(country)) {
+        return res.status(403).json({ msg: "O país informado  está em um formato inválido." });
+
+
+      } else if (!validateRating.test(rating)) {
+        return res.status(403).json({ msg: "A classificação indicativa está em um formato inválido." });
+
+
+      } else if (!validateIfIsString.test(director)) {
+        return res.status(403).json({ msg: "O diretor está em um formato inválido." });
+
+
+      } else if (!validateTypeShow.test(type_show)) {
+        return res.status(403).json({ msg: "O tipo de show informado está em um formato inválido." });
+
+
+      } else if (!validateYear.test(release_year)) {
+        return res.status(403).json({ msg: "o ano de lançamento está em um formato inválido." });
+
+
+      } else if (typeof cast !== 'string') {
+        return res.status(403).json({ msg: "O formato do elenco passado está em um formato inválido." });
+
+
+      } else if (!validateIfIsString.test(listed_in)) {
+        return res.status(403).json({ msg: "O listed_in passado está em um formato inválido." });
+      }
+
+      const query = `MATCH (s:ShowCatalog {id: ${id}})
+          SET s.type_show = "${type_show}",
+              s.title = "${title}",
+              s.director = "${director}",
+              s.cast = "${cast}",
+              s.country = "${country}",
+              s.date_added = "${date_added}",
+              s.release_year = ${release_year},
+              s.rating = "${rating}",
+              s.duration = "${duration}",
+              s.listed_in = "${listed_in}",
+              s.description_show = "${description_show}"
+          RETURN s
+         
+            `
+
+      const result = await session.run(query)
+      if (result.records.length === 0) {
+        res.status(400).json({ msg: "Não foi possível atualizar o show." })
+      }
+
+      const updateRelQuery = `
+
+      MATCH (s:ShowCatalog {id: ${id}})
+      OPTIONAL MATCH (s)-[:HAS_CAST]->(oldActor)
+      OPTIONAL MATCH (s)-[:DIRECTED_BY]->(oldDirector)
+      OPTIONAL MATCH (s)-[:LOCATED_IN]->(oldCountry)
+      DETACH DELETE oldActor
+      DETACH DELETE oldDirector
+      DETACH DELETE oldCountry
+      WITH s, split("${cast}", ', ') as newCast
+      UNWIND newCast as newActorName
+      MERGE (a:Actor {actor_name: newActorName})
+      MERGE (s)-[:HAS_CAST]->(a)
+      MERGE (s)-[:DIRECTED_BY]->(d:Director {director_name: "${director}"})
+      MERGE (s)-[:LOCATED_IN]->(c:Country {name_country: "${country}"})      
+      RETURN s`
+
+      const updateShowRelQuery = await session.run(updateRelQuery)
+      if (updateShowRelQuery.records.length === 0) {
+        res.status(400).json({ msg: "Não foi possível atualizar os relacionamentos de show." })
+      }
+
+      const response = {
+        records: updateShowRelQuery.records
+      }
+      res.status(201).json({ response, msg: "Show atualizado com sucesso." });
+    } catch (error) {
+      console.log(error);
+      res.status(500).json({ msg: "Não foi possível realizar a criação do show." });
+    } finally {
+      if (session) await session.close();
+    }
+  },
+
+  delete: async (req, res) => {
+    const session = driver.session()
+    try {
+      const id = req.body.id;
+
+      const query = `MATCH(s:ShowCatalog)
+        WHERE s.id = ${id}
+        DETACH DELETE s
+        RETURN s`
+      const result = await session.run(query)
+
+      if (result.records.length === 0) {
+        return res.status(404).json({ msg: "show não encontrado." });
+      }
+
+      const response = {
+        records: result.records,
+      }
+      res.status(200).json({ response, msg: "show apagado com sucesso." })
+    } catch (error) {
+      console.log(error);
+      res.status(500).json({ msg: "Não foi possível realizar a deleção do show." });
+    } finally {
+      if (session) await session.close();
+    }
+  }
+}
+
+module.exports = showController;

--- a/CRUD-Neo4j/index.js
+++ b/CRUD-Neo4j/index.js
@@ -1,12 +1,11 @@
 const express     = require('express');
 const app         = express();
 
+require("dotenv").config()
 const db          = require('./config/db/dbConnection');
 const router      = require('./routes/router');
 
-require("dotenv").config()
 const PORT        = process.env.PORT;
-
 
 // configuração para transporte dos dados em json.
 

--- a/CRUD-Neo4j/modelo.env
+++ b/CRUD-Neo4j/modelo.env
@@ -1,0 +1,4 @@
+PORT = 
+URI = 
+USER = 
+PASSWORD = 

--- a/CRUD-Neo4j/package.json
+++ b/CRUD-Neo4j/package.json
@@ -1,6 +1,6 @@
 {
   "name": "netflix_node_neo4j_crud",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Projeto de um CRUD utilizando NodeJS e o banco não relacional neo4j",
   "main": "index.js",
   "scripts": {
@@ -24,7 +24,6 @@
   },
   "homepage": "https://github.com/wesleyruanwr/projeto_UFC#readme",
   "dependencies": {
-    "cors": "^2.8.5",
     "dotenv": "^16.4.5",
     "express": "^4.19.2",
     "neo4j-driver": "^5.20.0"

--- a/CRUD-Neo4j/routes/director.js
+++ b/CRUD-Neo4j/routes/director.js
@@ -1,0 +1,30 @@
+const directorController = require('../controllers/directorController');
+
+const directorRouter     = require('express').Router();
+
+directorRouter
+.route('/director/add')
+.post((req,res) => directorController.create(req, res));
+
+directorRouter
+.route('/director/find')
+.get((req, res) => directorController.getDirectorByName(req, res));
+
+directorRouter
+.route('/director/findMany')
+.get((req, res) => directorController.getAllDirectorsInRange(req, res));
+
+directorRouter
+.route('/director/find-films')
+.get((req, res) => directorController.getFilmsDirectorRel(req, res))
+
+directorRouter
+.route('/director/update')
+.put((req, res) => directorController.update(req, res));
+
+directorRouter
+.route('/director/delete')
+.delete((req, res) => directorController.delete(req, res));
+ 
+
+module.exports = directorRouter

--- a/CRUD-Neo4j/routes/relations.js
+++ b/CRUD-Neo4j/routes/relations.js
@@ -1,0 +1,34 @@
+const relController = require('../controllers/relController');
+
+const relationRouter = require('express').Router();
+
+relationRouter
+.route('/relation/create')
+.post((req, res) => relController.create(req, res))
+
+relationRouter
+.route('/relation/director-show')
+.post((req, res) => relController.createRelDirectorShow(req, res))
+
+relationRouter
+.route('/relation/actor-show')
+.post((req, res) => relController.createRelActorShow(req, res));
+
+relationRouter
+.route('/relation/country-show')
+.post((req, res) => relController.createRelCountryShow(req, res));
+
+relationRouter
+.route('/relation/find-actor')
+.get((req, res) => relController.getActorShows(req, res));
+
+relationRouter
+.route('/relation/find-director')
+.get((req, res) => relController.getDirectorShows(req, res));
+
+relationRouter
+.route('/relation/find-country')
+.get((req, res) => relController.getCountryShows(req, res));
+
+
+module.exports = relationRouter

--- a/CRUD-Neo4j/routes/router.js
+++ b/CRUD-Neo4j/routes/router.js
@@ -1,6 +1,13 @@
-const router = require('express').Router()
-const actorRouter = require('./actor');
+const router         = require('express').Router()
+const actorRouter    = require('./actor');
+const directorRouter = require('./director');
+const relationRouter = require('./relations');
+const showRouter     = require('./showCatalog');
 
-router.use('/', actorRouter)
+
+router.use('/', actorRouter);
+router.use('/', directorRouter);
+router.use('/', showRouter);
+router.use('/', relationRouter);
 
 module.exports = router;

--- a/CRUD-Neo4j/routes/showCatalog.js
+++ b/CRUD-Neo4j/routes/showCatalog.js
@@ -1,0 +1,24 @@
+const showRouter     = require('express').Router();
+const showController = require('../controllers/showController')
+
+showRouter
+.route('/show/add')
+.post((req, res) => showController.create(req, res));
+
+showRouter
+.route('/show/getAll')
+.get((req, res) => showController.getAll(req, res));
+
+showRouter
+.route('/show/find')
+.get((req, res) => showController.getById(req, res));
+
+showRouter
+.route('/show/update')
+.put((req, res) => showController.update(req, res));
+
+showRouter
+.route('/show/delete')
+.delete((req, res) => showController.delete(req, res));
+
+module.exports = showRouter


### PR DESCRIPTION
Esta PR tem por finalidade enviar o CRUD finalizado. Futuramente haverão patchs de correções para melhorar legibilidade do código.

adições:

relController: 

- Cria o relacionamento entre os atributos director, cast e country do show.

-  Cria relacionamento entre diretor e show, além de também adicionar o diretor enviado via requisição como propriedade do ShowCatalog (caso haja um diretor, será adicionado o novo diretor e o relacionamento será criado.)

- Cria relacionamento entre ator e show, além de seguir o mesmo funcionamento acima, com a diferença que o novo ator será adicionado na lista de "cast" (elenco) do filme.

- Cria relacionamento entre o país (country) e o show, seguindo o mesmo funcionamento acima. Caso não haja nenhum país no relacionamento, o que for passado via requisição será o novo.


Além das funcionalidades de retornar os relacionamentos entre ator e filme, filme e diretor, bem como a "country" e diretor.

dbConfig:

- A função deste arquivo é encapsular as credenciais de acesso ao banco definidas no arquivo .env. Para ver o modelo de dados que devem ser passados nele, observar o "modelo.env" adicionado nesta PR.


arquivos de rota:

- São responsáveis por definir as rotas de acesso aos métodos HTTP como POST, GET, PUT e DELETE.


Corrigidos:

- Erro nas requisições: Algumas vezes, ao atualizar um ator a propriedade ator era atualizada, mas o nó do grafo permanecia alterado. Este erro também afetava country e director. 
- Credenciais de acesso nas controllers: Antes, as credenciais de acesso ao banco  estavam expostas na controller. Esta PR  liga as propriedades de acesso ao banco ao arquivo dbConfig.js


feedback: 

- Caso possua algum feedback de melhoria ou nova funcionalidade, entre em contato com o contribuidor Emanuel Ernesto para conversar sobre sua opinião e novos recursos.
